### PR TITLE
Make WSL bash execute .bashrc (to support ssh-agent)

### DIFF
--- a/git.bat
+++ b/git.bat
@@ -31,9 +31,9 @@ if [%1] == [] goto WITHOUT_ARGS
 	set args=%*
 	set "args=%args:\=\\%"
 
-	wsl env "WSLGIT_SH_CWD=%currentdir%" wslgit.sh %args%
+	wsl bash -ic 'env "WSLGIT_SH_CWD=%currentdir%" wslgit.sh %args%'
 	exit /b %errorlevel%
 
 :WITHOUT_ARGS
-	wsl env "WSLGIT_SH_CWD=%currentdir%" wslgit.sh
+	wsl bash -ic 'env "WSLGIT_SH_CWD=%currentdir%" wslgit.sh'
 	exit /b %errorlevel%


### PR DESCRIPTION
I had to make this change to enable using ssh-agent which I have configured in `.bashrc` (according to [GitHub's instructions](https://help.github.com/en/articles/working-with-ssh-key-passphrases), which I guess describes the common technique). This enables pushing to and pulling from remote repos using ssh keys, without leaving a passwordless ssh key on your disk.

A simple `wsl some commands` in cmd.exe doesn't seem to make bash run `.profile`, `.bash_profile`, nor `.bashrc`, so running `wsl bash -ic 'some commands'` looks like the only solution.

These changes seemed to work for me, but feel free to re-think it, make it configurable, or something. But I think something like this needs to be implemented.