### PR TITLE
Add support for 9p mounts in WSL2

### DIFF
--- a/wslgit.sh
+++ b/wslgit.sh
@@ -23,13 +23,17 @@ AWK="$(which gawk)";
 [[ -z "$AWK" ]] && echo "fatal: \"awk\" is not installed in WSL!" >&2 && exit 1;
 
 function get_mounted_drvfs() {
-	mount -t drvfs | "$AWK" '
+	mount -t drvfs,9p | "$AWK" '
 	function trim(s) { gsub(/^[ \t]+/, "", s); gsub(/[ \t]+$/, "", s); return s; }
 	{
-		if(split($0, lr, "type drvfs") < 2) next;
-		if(split(lr[1], part, "on") < 2) next;
+		if(split($0, lr, " type drvfs ") < 2) {
+			if(split($0, lr, " type 9p ") < 2) next;
+		}
+		if(split(lr[1], part, " on ") < 2) next;
 
-		drive = trim(substr(part[1],1,2));
+		if(substr(part[1], 2, 1) != ":") next;
+
+		drive = trim(substr(part[1], 1, 2));
 		mount_to = trim(part[2]);
 
 		print toupper(drive) "\n" mount_to;


### PR DESCRIPTION
I upgraded to WSL2 and this stopped working. By making the script accept mounts of type `9p` in addition to `drvfs`, I got it to work easily.

WSL2 also mounts `tools on /init type 9p`, so the script thought `TO` is a drive letter. I added a check for `:` as the second character.

Unfortunately, this doesn't work yet with repos that reside on the Linux disk. Their paths would be simpler to convert: `/home/x/repo/` in Linux is e.g. `\\wsl$\Ubuntu\home\x\repo\` in Windows. However, running a .bat script in a UNC path prints a warning (and it's only possible to run it in PowerShell). I'm not sure if that can be fixed.